### PR TITLE
Update neutralino.config.json

### DIFF
--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -3,6 +3,8 @@
   "port": 0,
   "defaultMode": "window",
   "url": "/resources/",
+  "enableHTTPServer": true,
+  "enableNativeAPI": true,
   "nativeBlockList": [
     "os.execCommand",
     "filesystem.removeDirectory",


### PR DESCRIPTION
Fixed missing enableHTTPServer and enableNativeAPI - now it works.

-- without this, the window says "The URL can’t be shown".